### PR TITLE
Initial mount macros and functions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,10 @@
-(defproject kehaar-mount "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+(defproject kehaar-mount "1.0.3-SNAPSOPT"
+  :description "Helpful function and macros for using kehaar with mount"
+  :url "https://github.com/democracyworks/kehaar-mount"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.10.0"]]
+  :dependencies [[org.clojure/clojure "1.10.0" :scope "provided"]
+                 [org.clojure/core.async "1.0.567" :scope "provided"]
+                 [democracyworks/kehaar "1.0.3" :scope "provided"]
+                 [mount "0.1.16" :scope "provided"]]
   :repl-options {:init-ns kehaar-mount.core})

--- a/src/kehaar_mount/core.clj
+++ b/src/kehaar_mount/core.clj
@@ -1,6 +1,56 @@
-(ns kehaar-mount.core)
+(ns kehaar-mount.core
+  (:require [kehaar-mount.impl :as impl]
+            [mount.core :refer [defstate]]))
 
-(defn foo
-  "I don't do a whole lot."
-  [x]
-  (println x "Hello, World!"))
+(defn start!
+  "Starts a kehaar mount state.
+
+  This is a replacement for `kehaar.configured/init!` that is intended to be
+  used in `mount.core/defstate`."
+  [connection config]
+  (impl/start! connection config))
+
+(defn stop!
+  "Stops a kehaar state started by `start!`"
+  [kehaar-state]
+  (impl/stop! kehaar-state))
+
+(defmacro defconsumer
+  "Defines (using `mount.core/defstate`) a kehaar consumer.
+
+  `:start` initializes kehaar consumer state and returns the handler function.
+
+  `:stop` cleans up kehaar state for this consumer.
+
+  Options:
+
+  :kehaar -- the kehaar state
+  :f      -- a handler function
+  :id     -- a kehaar config id (default: fully-qualified name)"
+  [name & {:keys [f kehaar id]}]
+  (let [id (or id (symbol (str *ns*) name))]
+    `(defstate ~name
+       :start (let [f# ~f
+                    state# (impl/start-consumer! ~kehaar f# ~id)]
+                (with-meta f# {::state state}))
+       :stop (impl/stop-consumer! (::state (meta ~name))))))
+
+(defmacro defpublisher
+  "Defines (using `mount.core/defstate`) a kehaar publisher.
+
+  `:start` creates an `async/chan` for the publisher, initializes kehaar
+  publisher state, and returns a wired-up function for the asunc/chan.
+
+  `:stop` closes the channel and cleans up kehaar state for this publisher.
+
+  Options:
+
+  :kehaar -- the kehaar state
+  :id     -- a kehaar config id (default: fully-qualified name)"
+  [name & {:keys [kehaar id]}]
+  (let [id (or id (symbol (str *ns*) name))]
+    `(defstate ~name
+       :start (let [state# (impl/start-publisher! ~kehaar ~id)
+                    f# (:f state#)]
+                (with-meta f# {::state state}))
+       :stop (impl/stop-publisher! (::state (meta ~name))))))

--- a/src/kehaar_mount/impl.clj
+++ b/src/kehaar_mount/impl.clj
@@ -1,0 +1,110 @@
+(ns kehaar-mount.impl
+  (:require [clojure.core.async :as async]
+            [kehaar.configured :as k.configured]
+            [kehaar.jobs :as k.jobs]
+            [kehaar.wire-up :as k.wire-up]))
+
+;;; Functions for searching a kehaar.configured map for a service id
+;; Service ids are specified using `:id` or `:f` in the config map
+
+(defn flatten-config
+  [kehaar-configured-map]
+  (flatten
+   (for [[section configs] kehaar-configured-map]
+     (map #(-> %
+               (assoc ::section section)
+               (assoc ::id (some % [:id :f])))
+          configs))))
+
+(defn- assert-single-config [id s]
+  (case (count s)
+    0 (throw (ex-info (str "No kehaar config found for id: " id)
+                      {:id id, :config (doall s)}))
+    1 s
+    (throw (ex-info (str "Multiple kehaar configs found for id: " id)
+                    {:id id, :config (doall s)}))))
+
+(defn- find-consumer [kehaar-state id]
+  (->> (:config kehaar-state)
+       (filter (comp #{id} ::id))
+       (filter (comp #{:incoming-services :incoming-events :incoming-jobs} ::section))
+       (assert-single-config id)
+       (first)))
+
+(defn- find-publisher [kehaar-state id]
+  (->> (:config kehaar-state)
+       (filter (comp #{id} ::id))
+       (filter (comp #{:external-services :outgoing-events :outgoing-jobs} ::section))
+       (assert-single-config id)
+       (first)))
+
+;;; Kehaar state
+
+(defn start!
+  [connection config]
+  (let [global-config (select-keys config [:event-exchanges])
+        service-config (dissoc config :event-exchanges)]
+    {:state (k.configured/init! connection global-config)
+     :connection connection
+     :config (flatten-config service-config)}))
+
+(defn stop!
+  [kehaar-state]
+  (k.configured/shutdown! (:state kehaar-state)))
+
+;;; Consumers
+
+(defn init-consumer [kehaar-state cfg]
+  (let [connection (:connection kehaar-state)]
+    (case (::section cfg)
+      :incoming-services (k.configured/init-incoming-service! connection cfg)
+      :incoming-events (k.configured/init-incoming-event! connection cfg)
+      :incoming-jobs (k.configured/init-incoming-job! connection cfg))))
+
+(defn start-consumer!
+  "Starts a consumer, returning a map of states."
+  [kehaar-state handler-fn id]
+  (let [config (-> (find-consumer kehaar-state id)
+                   (assoc :f handler-fn))]
+    {:kehaar-part (init-consumer kehaar-state config)}))
+
+(defn stop-consumer!
+  "Stops a consumer started with `start-consumer!`"
+  [{:keys [kehaar-part]}]
+  (k.configured/shutdown-part! kehaar-part))
+
+;;; Publishers
+
+(defn init-publisher [kehaar-state cfg]
+  (let [connection (:connection kehaar-state)]
+    (case (::section cfg)
+      :external-services (k.configured/init-external-service! connection cfg)
+      :outgoing-events (k.configured/init-outgoing-event! connection cfg)
+      :outgoing-jobs (k.configured/init-outgoing-job! connection cfg))))
+
+(defn wire-up-publisher [cfg]
+  (case (::section cfg)
+    :external-services (if (:response cfg)
+                         (k.wire-up/async->fn (:channel cfg))
+                         (k.wire-up/async->fire-and-forget-fn (:channel cfg)))
+    :outgoing-events (partial async/>!! (:channel cfg))
+    :outgoing-jobs (k.jobs/async->job (:jobs-chan cfg))))
+
+(defn start-publisher!
+  "Starts a publisher, returning a map of states and a wired-up publisher
+  function `:f`."
+  [kehaar-state id]
+  (let [channel (async/chan)
+        config (-> (find-publisher kehaar-state id)
+                   (assoc :channel channel
+                          ;; jobs uses this key instead of :channel
+                          :jobs-chan channel))]
+    {:kehaar-part (init-publisher kehaar-state config)
+     :f (wire-up-publisher config)
+     :channel channel}))
+
+(defn stop-publisher!
+  "Stops a publisher started with `start-publisher!`"
+  [{:keys [kehaar-part channel]}]
+  (k.configured/shutdown-part! kehaar-part)
+  (async/close! channel))


### PR DESCRIPTION
I started working on converting some services to mount recently, and it made me want to revisit some of the ideas in democracyworks/kehaar#47.

The main idea is that rather than one big piece of kehaar-configured state, there are multiple smaller pieces of state that rely on each other:

* kehaar state: just the tiniest bit of setup code from `kehaar.configured/init!`, plus it stores a normalized config map
* consumer: a handler function with state stored in metadata
* publisher: a publishing function with state stored in metadata

```clj
(ns your-service.queue
  (:require [kehaar-mount.core :as km]
            [mount.core :refer [defstate])))

(defstate connection ...)

(defstate kehaar
  :start (km/start! connection (get-in config [:rabbitmq :kehaar]))
  :stop (km/stop! kehaar)


(ns your-service.handlers
  (:require [kehaar-mount.core :refer [defconsumer defpublisher]
            [your-service.queue :refer [kehaar])))

;; Publishers -- channels are managed for you
(defpublisher schedule-message-faf :kehaar kehaar)
(defpublisher send-update-event :kehaar kehaar) 

;; Consumers
(defn my-consumer* [schedule-fn update-event-fn message]
   ...)

(defconsumer my-consumer
  :f (partial my-consumer* schedule-message-faf send-update-event)
  :kehaar kehaar)
```

For the sake of reducing the number of code changes across services, the above setup uses the same config format as `kehaar.configured` (the intent is just to make it easier to use with mount). The one config difference is instead of publishers specifying a `:channel` that is used for publishing, this library wires-up those channels for you, so instead it looks for a `:f` that will be used for publishing:

```clj
;; publishers use `:f` instead of `:channel`
{:external-services
 [{:queue "scheduled-message-works.message.schedule-faf"
   :f your-service.handlers/schedule-message-faf
   :response false}]
 :outgoing-events
 [{:exchange "events"
   :routing-key "your-service.update"
   :f your-service.handlers/send-update-event}]}
```


Edit: the macros are just sugar of course, and we could be more explicit without them, though it's a bit more boilerplate:
```clj
(defstate schedule-message-faf
  :start (km/start-publisher! kehaar "schedule-message-faf")
  :stop (km/stop-publisher! schedule-message-faf))

(defstate send-update-event
  :start (km/start-publisher! kehaar "send-update-event")
  :stop (km/stop-publisher! send-update-event))

(defstate my-consumer
  :start (let [f (partial my-consumer* schedule-message-faf send-update-event)]
           (km/start-consumer! kehaar f "my-consumer"))
  :stop (km/stop-consumer! my-consumer))
```